### PR TITLE
fix: token max count & sentence case setting

### DIFF
--- a/src/Settings/SettingsView.ts
+++ b/src/Settings/SettingsView.ts
@@ -138,7 +138,7 @@ export default class SettingsView extends PluginSettingTab {
 
 		// Add Toggle File Context button
 		new Setting(containerEl)
-			.setName("Enable File Context")
+			.setName("Enable file context")
 			.setDesc("Enable the file context feature that allows AI to access vault files. When disabled, AI will not have access to any files from your vault.")
 			.addToggle((toggle) => {
 				toggle

--- a/src/main.ts
+++ b/src/main.ts
@@ -81,7 +81,7 @@ const defaultSettings = {
 		quality: "standard" as ImageQuality,
 	},
 	chatSettings: {
-		maxTokens: 8192,
+		maxTokens: 4096,
 		temperature: 0.65,
 		GPT4All: {},
 		openAI: {


### PR DESCRIPTION
## Summary
- Cherry-pick non-breaking token max count for GPT 3.5 Turbo (4096 instead of 8192)
- Sentence case "Enable file context" setting label

## Test plan
- [ ] Verify GPT 3.5 Turbo works with the updated max token count
- [ ] Verify settings menu shows "Enable file context" in sentence case