### PR TITLE
fix: register Ollama models globally and add request timeout

### DIFF
--- a/src/Settings/SettingsView.ts
+++ b/src/Settings/SettingsView.ts
@@ -234,6 +234,10 @@ export default class SettingsView extends PluginSettingTab {
 							this.plugin.settings.ollamaHost
 						);
 						this.plugin.settings.ollamaModels = foundModels;
+						// Register in global models/modelNames so FAB/Modal/Widget dropdowns see them
+						const built = buildOllamaModels(foundModels);
+						Object.assign(models, built.models);
+						Object.assign(modelNames, built.names);
 						await this.plugin.saveSettings();
 						// Refresh the settings display
 						this.display();

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -125,6 +125,7 @@ export async function ollamaMessage(params: ChatParams, host: string) {
 		apiKey: "ollama",
 		baseURL: `${host}/v1`,
 		dangerouslyAllowBrowser: true,
+		timeout: 30000,
 	});
 
 	const { model, messages, tokens, temperature } = params;


### PR DESCRIPTION
## Summary
- Registers Ollama models in global `models`/`modelNames` maps after refresh so FAB, Modal, and Widget dropdowns can see them
- Adds 30s request timeout to Ollama API client to prevent indefinite hangs

Fixes #261 (Ollama model selection in FAB chat)

## Test plan
- [ ] Open FAB chat, select Ollama provider, verify models appear in dropdown
- [ ] Open Modal, verify Ollama models appear
- [ ] Send a chat with Ollama — verify it doesn't lock up indefinitely on failure (30s timeout)
- [ ] Verify existing OpenAI/other provider flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)